### PR TITLE
Watefox browser support for Linux

### DIFF
--- a/pkg/browsers/defined_linux.go
+++ b/pkg/browsers/defined_linux.go
@@ -27,6 +27,7 @@ package browsers
 var DefinedBrowsers = []BrowserDef{
 	Firefox,
 	Librewolf,
+	Waterfox,
 	Chrome,
 	Chromium,
 	Brave,

--- a/pkg/browsers/defined_linux.go
+++ b/pkg/browsers/defined_linux.go
@@ -81,6 +81,13 @@ var (
 		"/nonexistent",
 		"~/.var/app/io.gitlab.librewolf-community/.librewolf",
 	)
+
+	Waterfox = MozBrowser(
+		"waterfox",
+		"~/.waterfox",
+		"/nonexistent",
+		"~/.var/app/net.waterfox.waterfox",
+	)
 )
 
 func AddBrowserDef(b BrowserDef) {

--- a/pkg/browsers/defined_linux.go
+++ b/pkg/browsers/defined_linux.go
@@ -87,7 +87,7 @@ var (
 		"waterfox",
 		"~/.waterfox",
 		"/nonexistent",
-		"~/.var/app/net.waterfox.waterfox",
+		"~/.var/app/net.waterfox.waterfox/.waterfox",
 	)
 )
 


### PR DESCRIPTION
Hi!
Added Waterfox support for Linux. Tested AUR package and Flatpak on Manjaro.

Had to append additional `/.waterfox` to Flatpak path, otherwise it was detecting the profile but was not loading bookmarks.