### PR TITLE
add Zen browser support

### DIFF
--- a/pkg/browsers/defined_darwin.go
+++ b/pkg/browsers/defined_darwin.go
@@ -27,6 +27,7 @@ package browsers
 var DefinedBrowsers = []BrowserDef{
 	Firefox,
 	Librewolf,
+	Zen,
 	Chrome,
 	Chromium,
 	QuteBrowser,
@@ -67,6 +68,12 @@ var (
 	Librewolf = MozBrowser(
 		"librewolf",
 		"~/Library/Application Support/Librewolf",
+		"", "",
+	)
+
+	Zen = MozBrowser(
+		"zen",
+		"~/Library/Application Support/zen",
 		"", "",
 	)
 )

--- a/pkg/browsers/defined_linux.go
+++ b/pkg/browsers/defined_linux.go
@@ -28,6 +28,7 @@ var DefinedBrowsers = []BrowserDef{
 	Firefox,
 	Librewolf,
 	Waterfox,
+	Zen,
 	Chrome,
 	Chromium,
 	Brave,
@@ -88,6 +89,13 @@ var (
 		"~/.waterfox",
 		"/nonexistent",
 		"~/.var/app/net.waterfox.waterfox/.waterfox",
+	)
+
+	Zen = MozBrowser(
+		"zen",
+		"~/.zen",
+		"/nonexistent",
+		"~/.var/app/app.zen_browser.zen/.zen",
 	)
 )
 


### PR DESCRIPTION
I have tested the addition of [Zen](https://zen-browser.app/) via the recommended commands on Linux with a repository based install. I have not tested a Flatpack install nor a Mac install, but I did validate the paths are correct.

```
go run ./cmd/gosuki detect
go run ./cmd/gosuki --tui start
```

Both worked as expected.